### PR TITLE
chore: add .gitignore for devops to exclude terraform state files

### DIFF
--- a/devops/.gitignore
+++ b/devops/.gitignore
@@ -1,0 +1,28 @@
+# Terraform
+*.tfstate
+*.tfstate.*
+*.tfvars
+*.tfvars.json
+.terraform/
+.terraform.lock.hcl
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+.DS_Store
+
+# Environment
+.env
+.env.local
+*.log
+
+# OS
+Thumbs.db


### PR DESCRIPTION
This pull request updates the `.gitignore` file in the `devops` directory to better handle common development, infrastructure, and environment files. The changes help prevent sensitive or unnecessary files from being committed to the repository.

Improvements to `.gitignore`:

* Added rules to ignore Terraform state, variable, and crash files, as well as the `.terraform` directory and lock files.
* Added patterns to ignore IDE-specific files and directories such as `.idea/`, `.vscode/`, and swap files.
* Included entries to ignore environment files (e.g., `.env`, `.env.local`) and log files.
* Added rules to ignore common OS-generated files like `.DS_Store` and `Thumbs.db`.